### PR TITLE
Cleaned up machines without TM data

### DIFF
--- a/timemachine_model.php
+++ b/timemachine_model.php
@@ -9,42 +9,42 @@ class Timemachine_model extends \Model
         parent::__construct('id', 'timemachine'); //primary key, tablename
         $this->rs['id'] = '';
         $this->rs['serial_number'] = $serial; $this->rt['serial_number'] = 'VARCHAR(255) UNIQUE';
-        $this->rs['last_success'] = ''; // Datetime of last successful backup
-        $this->rs['last_failure'] = ''; // Datetime of last failure
-        $this->rs['last_failure_msg'] = ''; // Message of the last failure
+        $this->rs['last_success'] = null; // Datetime of last successful backup
+        $this->rs['last_failure'] = null; // Datetime of last failure
+        $this->rs['last_failure_msg'] = null; // Message of the last failure
         $this->rs['duration'] = 0; // Duration in seconds
         $this->rs['always_show_deleted_backups_warning'] = 0; // bool
         $this->rs['auto_backup'] = 0; // bool
         $this->rs['bytes_available'] = 0; $this->rt['bytes_available'] = 'BIGINT';
         $this->rs['bytes_used'] = 0; $this->rt['bytes_used'] = 'BIGINT';
-        $this->rs['consistency_scan_date'] = '';
-        $this->rs['date_of_latest_warning'] = '';
-        $this->rs['destination_id'] = '';
-        $this->rs['destination_uuids'] = ''; $this->rt['destination_uuids'] = 'TEXT';
-        $this->rs['last_known_encryption_state'] = '';
-        $this->rs['result'] = '';
-        $this->rs['root_volume_uuid'] = '';
-        $this->rs['snapshot_dates'] = ''; $this->rt['snapshot_dates'] = 'TEXT';
-        $this->rs['exclude_by_path'] = ''; $this->rt['exclude_by_path'] = 'TEXT';
-        $this->rs['host_uuids'] = '';
-        $this->rs['last_configuration_trace_date'] = '';
-        $this->rs['last_destination_id'] = '';
-        $this->rs['localized_disk_image_volume_name'] = '';
+        $this->rs['consistency_scan_date'] = null;
+        $this->rs['date_of_latest_warning'] = null;
+        $this->rs['destination_id'] = null;
+        $this->rs['destination_uuids'] = null; $this->rt['destination_uuids'] = 'TEXT';
+        $this->rs['last_known_encryption_state'] = null;
+        $this->rs['result'] = null;
+        $this->rs['root_volume_uuid'] = null;
+        $this->rs['snapshot_dates'] = null; $this->rt['snapshot_dates'] = 'TEXT';
+        $this->rs['exclude_by_path'] = null; $this->rt['exclude_by_path'] = 'TEXT';
+        $this->rs['host_uuids'] = null;
+        $this->rs['last_configuration_trace_date'] = null;
+        $this->rs['last_destination_id'] = null;
+        $this->rs['localized_disk_image_volume_name'] = null;
         $this->rs['mobile_backups'] = 0; // bool
-        $this->rs['skip_paths'] = ''; $this->rt['skip_paths'] = 'TEXT';
+        $this->rs['skip_paths'] = null; $this->rt['skip_paths'] = 'TEXT';
         $this->rs['skip_system_files'] = 0; // bool
-        $this->rs['alias_volume_name'] = '';
-        $this->rs['earliest_snapshot_date'] = '';
+        $this->rs['alias_volume_name'] = null;
+        $this->rs['earliest_snapshot_date'] = null;
         $this->rs['is_network_destination'] = 0; // bool
-        $this->rs['latest_snapshot_date'] = '';
-        $this->rs['mount_point'] = '';
-        $this->rs['network_url'] = '';
-        $this->rs['server_display_name'] = '';
+        $this->rs['latest_snapshot_date'] = null;
+        $this->rs['mount_point'] = null;
+        $this->rs['network_url'] = null;
+        $this->rs['server_display_name'] = null;
         $this->rs['snapshot_count'] = 0;
-        $this->rs['time_capsule_display_name'] = '';
-        $this->rs['volume_display_name'] = '';
+        $this->rs['time_capsule_display_name'] = null;
+        $this->rs['volume_display_name'] = null;
         $this->rs['destinations'] = 0;
-        $this->rs['apfs_snapshots'] = ''; $this->rt['apfs_snapshots'] = 'TEXT';
+        $this->rs['apfs_snapshots'] = null; $this->rt['apfs_snapshots'] = 'TEXT';
         
         if ($serial) {
             $this->retrieve_record($serial);
@@ -87,7 +87,6 @@ class Timemachine_model extends \Model
      **/
     public function process($data)
     {
-        
         // If data is empty, throw error
         if (! $data) {
             throw new Exception("Error Processing Time Machine Module Request: No data found", 1);
@@ -120,189 +119,187 @@ class Timemachine_model extends \Model
             $parser = new CFPropertyList();
             $parser->parse($data, CFPropertyList::FORMAT_XML);
             $plist = $parser->toArray();
-            
-            // Check if Time Machine is active/setup
-            if ( array_key_exists("Destinations",$plist)){
-                
-                // Array of ints
-                $ints =  array('always_show_deleted_backups_warning', 'auto_backup', 'bytes_available', 'bytes_used', 'mobile_backups', 'skip_system_files', 'is_network_destination', 'snapshot_count');
 
-                // Array of elements nested in Destination array
-                $nested =  array('backup_alias', 'bytes_available', 'bytes_used', 'consistency_scan_date', 'date_of_latest_warning', 'destination_id', 'last_known_encryption_state', 'result', 'root_volume_uuid');
+            // Array of ints
+            $ints =  array('always_show_deleted_backups_warning', 'auto_backup', 'bytes_available', 'bytes_used', 'mobile_backups', 'skip_system_files', 'is_network_destination', 'snapshot_count');
 
-                // Array of booleans
-                $bools =  array('always_show_deleted_backups_warning','auto_backup','mobile_backups','skip_system_files','is_network_destination');
+            // Array of elements nested in Destination array
+            $nested =  array('backup_alias', 'bytes_available', 'bytes_used', 'consistency_scan_date', 'date_of_latest_warning', 'destination_id', 'last_known_encryption_state', 'result', 'root_volume_uuid');
 
-                // Translate battery strings to db fields
-                $translate = array(
-                    'latestSnapshotDate' => 'last_success', // The mis-match is correct
-                    'AlwaysShowDeletedBackupsWarning' => 'always_show_deleted_backups_warning',
-                    'AutoBackup' => 'auto_backup',
-                    'BytesAvailable' => 'bytes_available',
-                    'BytesUsed' => 'bytes_used',
-                    'ConsistencyScanDate' => 'consistency_scan_date',
-                    'condition' => 'condition',
-                    'DateOfLatestWarning' => 'date_of_latest_warning',
-                    'DestinationID' => 'destination_id',
-                    'LastKnownEncryptionState' => 'last_known_encryption_state',
-                    'RESULT' => 'result',
-                    'RootVolumeUUID' => 'root_volume_uuid',
-                    'LastConfigurationTraceDate' => 'last_configuration_trace_date',
-                    'LastDestinationID' => 'last_destination_id',
-                    'LocalizedDiskImageVolumeName' => 'localized_disk_image_volume_name',
-                    'MobileBackups' => 'mobile_backups',
-                    'SkipSystemFiles' => 'skip_system_files',
-                    'alias_volume_name' => 'alias_volume_name',
-                    'earliest_snapshot_date' => 'earliest_snapshot_date',
-                    'is_network_destination' => 'is_network_destination',
-                    'latestSnapshotDate' => 'latest_snapshot_date',
-                    'mount_point' => 'mount_point',
-                    'network_url' => 'network_url',
-                    'server_display_name' => 'server_display_name',
-                    'snapshot_count' => 'snapshot_count',
-                    'time_capsule_display_name' => 'time_capsule_display_name',
-                    'volume_display_name' => 'volume_display_name',
-                    'apfs_snapshots' => 'apfs_snapshots'
-                );
+            // Array of booleans
+            $bools =  array('always_show_deleted_backups_warning','auto_backup','mobile_backups','skip_system_files','is_network_destination');
 
-                // Traverse the xml with translations
-                foreach ($translate as $search => $field) {  
-                    // If key is not empty, save it to the object
-                    if (! empty($plist[$search]) && ! in_array($field, $nested) && $plist[$search] != "None" && isset($plist[$search])) { 
-                        $this->$field = $plist[$search];
-                    } else if (in_array($field, $nested) && isset($plist["Destinations"][0][$search])){
-                        // If a nested element, extract from nested array
-                        $this->$field = $plist["Destinations"][0][$search];
-                    } else if (array_key_exists($search, $plist) && in_array($field, $bools) && $plist[$search] == true){
-                        // If true boolean, set accordingly
-                        $this->$field = '1';
-                    } else if (array_key_exists($search, $plist) && in_array($field, $bools) && $plist[$search] == false){
-                        // If false boolean, set accordingly
-                        $this->$field = '0';
-                    } else if ( ! array_key_exists($search, $plist) && in_array($field, $bools)){
-                        // If boolean and does not exist in plist, set to null
-                        $this->$field = null;
-                    } else if (array_key_exists($search, $plist) && in_array($field, $ints) && $plist[$search] == "0"){
-                        // Set the int to 0 if it's 0
-                        $this->$field = $plist[$search];
-                    } else if ( ! array_key_exists($search, $plist) && in_array($field, $ints)){
-                        // If int and does not exist in plist, set to null
-                        $this->$field = null;
-                    } else if (in_array($field, $ints)){
-                        // Set the int to 0 if it's 0
-                        $this->$field = 0;
-                    } else {  
-                        // Else, null the value
-                        $this->$field = '';
+            // Translate battery strings to db fields
+            $translate = array(
+                'latestSnapshotDate' => 'last_success', // The mis-match is correct
+                'AlwaysShowDeletedBackupsWarning' => 'always_show_deleted_backups_warning',
+                'AutoBackup' => 'auto_backup',
+                'BytesAvailable' => 'bytes_available',
+                'BytesUsed' => 'bytes_used',
+                'ConsistencyScanDate' => 'consistency_scan_date',
+                'condition' => 'condition',
+                'DateOfLatestWarning' => 'date_of_latest_warning',
+                'DestinationID' => 'destination_id',
+                'LastKnownEncryptionState' => 'last_known_encryption_state',
+                'RESULT' => 'result',
+                'RootVolumeUUID' => 'root_volume_uuid',
+                'LastConfigurationTraceDate' => 'last_configuration_trace_date',
+                'LastDestinationID' => 'last_destination_id',
+                'LocalizedDiskImageVolumeName' => 'localized_disk_image_volume_name',
+                'MobileBackups' => 'mobile_backups',
+                'SkipSystemFiles' => 'skip_system_files',
+                'alias_volume_name' => 'alias_volume_name',
+                'earliest_snapshot_date' => 'earliest_snapshot_date',
+                'is_network_destination' => 'is_network_destination',
+                'latestSnapshotDate' => 'latest_snapshot_date',
+                'mount_point' => 'mount_point',
+                'network_url' => 'network_url',
+                'server_display_name' => 'server_display_name',
+                'snapshot_count' => 'snapshot_count',
+                'time_capsule_display_name' => 'time_capsule_display_name',
+                'volume_display_name' => 'volume_display_name',
+                'apfs_snapshots' => 'apfs_snapshots'
+            );
+
+            // Traverse the xml with translations
+            foreach ($translate as $search => $field) {  
+                // If key is not empty, save it to the object
+                if (! empty($plist[$search]) && ! in_array($field, $nested) && $plist[$search] != "None" && isset($plist[$search])) { 
+                    $this->$field = $plist[$search];
+                } else if (in_array($field, $nested) && isset($plist["Destinations"][0][$search])){
+                    // If a nested element, extract from nested array
+                    $this->$field = $plist["Destinations"][0][$search];
+                } else if (array_key_exists($search, $plist) && in_array($field, $bools) && $plist[$search] == true){
+                    // If true boolean, set accordingly
+                    $this->$field = '1';
+                } else if (array_key_exists($search, $plist) && in_array($field, $bools) && $plist[$search] == false){
+                    // If false boolean, set accordingly
+                    $this->$field = '0';
+                } else if ( ! array_key_exists($search, $plist) && in_array($field, $bools)){
+                    // If boolean and does not exist in plist, set to null
+                    $this->$field = null;
+                } else if (array_key_exists($search, $plist) && in_array($field, $ints) && $plist[$search] == "0"){
+                    // Set the int to 0 if it's 0
+                    $this->$field = $plist[$search];
+                } else if ( ! array_key_exists($search, $plist) && in_array($field, $ints)){
+                    // If int and does not exist in plist, set to null
+                    $this->$field = null;
+                } else if (in_array($field, $ints)){
+                    // Set the int to 0 if it's 0
+                    $this->$field = 0;
+                } else {  
+                    // Else, null the value
+                    $this->$field = null;
+                }
+            }
+
+            // Parse log data from the legacy key
+            $start = ''; // Start date
+            foreach (explode("\n", $plist["legacy_output"]) as $line) {
+                $date = substr($line, 0, 19);
+                $message = substr($line, 21);
+
+                if (preg_match('/^Starting (automatic|manual) backup/', $message)) {
+                    $start = $date;
+                } elseif (preg_match('/^Backup completed successfully/', $message)) {
+                    if ($start) {
+                        $this->duration = strtotime($date) - strtotime($start);
+                    } else {
+                        $this->duration = 0;
+                    }
+                    $this->last_success = $date;
+                } elseif (preg_match('/^Backup failed/', $message)) {
+                    $this->last_failure = $date;
+                    $this->last_failure_msg = $message;
+                }
+            }
+
+            // Verify last_success is not blank
+            if (array_key_exists("latestSnapshotDate", $plist) && empty($last_success)) {
+                $this->last_success = str_replace(" +0000","",$plist["latestSnapshotDate"]);
+            }
+
+            // Format dates, if they exist
+            if (array_key_exists("earliest_snapshot_date", $plist) && empty($last_success)) {
+                $this->earliest_snapshot_date = str_replace(" +0000","",$plist["earliest_snapshot_date"]);
+            }
+            if (array_key_exists("latestSnapshotDate", $plist) && empty($last_success)) {
+                $this->latest_snapshot_date = str_replace(" +0000","",$plist["latestSnapshotDate"]);
+            }
+
+            // Condense arrays into strings after checking if they exist
+            if (array_key_exists("Destinations",$plist) && array_key_exists("DestinationUUIDs",$plist["Destinations"][0])){
+                $this->destination_uuids = implode(", ", $plist["Destinations"][0]["DestinationUUIDs"]);
+            } else {
+                $this->destination_uuids = null;
+            }
+
+            if (array_key_exists("Destinations",$plist) && array_key_exists("SnapshotDates",$plist["Destinations"][0])){
+                $this->snapshot_dates = implode(", ", $plist["Destinations"][0]["SnapshotDates"]);
+            } else {
+                $this->snapshot_dates = null;
+            }
+
+            if (array_key_exists("ExcludeByPath",$plist)){
+                $this->exclude_by_path = implode(", ", $plist["ExcludeByPath"]);
+            } else {
+                $this->exclude_by_path = null;
+            }
+
+            if (array_key_exists("HostUUIDs",$plist)){
+                $this->host_uuids = implode(", ", $plist["HostUUIDs"]);
+            } else {
+                $this->host_uuids = null;
+            }
+
+            if (array_key_exists("SkipPaths",$plist)){
+                $this->skip_paths = implode(", ", $plist["SkipPaths"]);
+            } else {
+                $this->skip_paths = null;
+            }
+
+            // Set destinations count
+            if (array_key_exists("Destinations",$plist)){
+                $this->destinations = count($plist["Destinations"]);
+            } else {
+                $this->destinations = "0";
+            }
+
+            // Format apfs_snapshots data, if it exist
+            if (array_key_exists("apfs_snapshots", $plist)) {
+
+                $apfs_array = explode("\n", $plist["apfs_snapshots"]);
+                array_shift($apfs_array);
+                $apfs_snapshots = null;
+                foreach ($apfs_array as $apfs_element) {
+                    // Check that element is not empty
+                    if ($apfs_element != ""){
+                        $date = DateTime::createFromFormat('Y-m-d-His', $apfs_element);
+                        $apfs_unix = $date->format('U');
+                        $apfs_snapshots = $apfs_unix.", ".$apfs_snapshots;
                     }
                 }
+                $this->apfs_snapshots = $apfs_snapshots;
+            }
 
-                // Parse log data from the legacy key
-                $start = ''; // Start date
-                foreach (explode("\n", $plist["legacy_output"]) as $line) {
-                    $date = substr($line, 0, 19);
-                    $message = substr($line, 21);
-
-                    if (preg_match('/^Starting (automatic|manual) backup/', $message)) {
-                        $start = $date;
-                    } elseif (preg_match('/^Backup completed successfully/', $message)) {
-                        if ($start) {
-                            $this->duration = strtotime($date) - strtotime($start);
-                        } else {
-                            $this->duration = 0;
-                        }
-                        $this->last_success = $date;
-                    } elseif (preg_match('/^Backup failed/', $message)) {
-                        $this->last_failure = $date;
-                        $this->last_failure_msg = $message;
-                    }
+            // Fill in older legacy values
+            if (array_key_exists("Destinations", $plist) && array_key_exists("legacy_output", $plist) && $plist["legacy_output"] == "Mac OS X 10.12+ not supported with legacy Time Machine log output") {
+                // Null the duration because we can't get that on 10.12+ *sad panda*
+                $this->duration = null;
+                if ($plist["Destinations"][0]["RESULT"] != "0"){
+                    // Record failure time using same format as legacy
+                    $this->last_failure = date("Y-m-d H:i:s");
+                    // Record the result for processing by the UI view
+                    $this->last_failure_msg = $plist["Destinations"][0]["RESULT"];
                 }
-
-                // Verify last_success is not blank
-                if (array_key_exists("latestSnapshotDate", $plist) && empty($last_success)) {
-                    $this->last_success = str_replace(" +0000","",$plist["latestSnapshotDate"]);
-                }
-
-                // Format dates, if they exist
-                if (array_key_exists("earliest_snapshot_date", $plist) && empty($last_success)) {
-                    $this->earliest_snapshot_date = str_replace(" +0000","",$plist["earliest_snapshot_date"]);
-                }
-                if (array_key_exists("latestSnapshotDate", $plist) && empty($last_success)) {
-                    $this->latest_snapshot_date = str_replace(" +0000","",$plist["latestSnapshotDate"]);
-                }
-
-                // Condense arrays into strings after checking if they exist
-                if (array_key_exists("Destinations",$plist) && array_key_exists("DestinationUUIDs",$plist["Destinations"][0])){
-                    $this->destination_uuids = implode(", ", $plist["Destinations"][0]["DestinationUUIDs"]);
-                } else {
-                    $this->destination_uuids = "";
-                }
-
-                if (array_key_exists("Destinations",$plist) && array_key_exists("SnapshotDates",$plist["Destinations"][0])){
-                    $this->snapshot_dates = implode(", ", $plist["Destinations"][0]["SnapshotDates"]);
-                } else {
-                    $this->snapshot_dates = "";
-                }
-
-                if (array_key_exists("ExcludeByPath",$plist)){
-                    $this->exclude_by_path = implode(", ", $plist["ExcludeByPath"]);
-                } else {
-                    $this->exclude_by_path = "";
-                }
-
-                if (array_key_exists("HostUUIDs",$plist)){
-                    $this->host_uuids = implode(", ", $plist["HostUUIDs"]);
-                } else {
-                    $this->host_uuids = "";
-                }
-
-                if (array_key_exists("SkipPaths",$plist)){
-                    $this->skip_paths = implode(", ", $plist["SkipPaths"]);
-                } else {
-                    $this->skip_paths = "";
-                }
-
-                // Set destinations count
-                if (array_key_exists("Destinations",$plist)){
-                    $this->destinations = count($plist["Destinations"]);
-                } else {
-                    $this->destinations = "0";
-                }
-
-                // Format apfs_snapshots data, if it exist
-                if (array_key_exists("apfs_snapshots", $plist)) {
-
-                    $apfs_array = explode("\n", $plist["apfs_snapshots"]);
-                    array_shift($apfs_array);
-                    $apfs_snapshots = "";
-                    foreach ($apfs_array as $apfs_element) {
-                        // Check that element is not empty
-                        if ($apfs_element != ""){
-                            $date = DateTime::createFromFormat('Y-m-d-His', $apfs_element);
-                            $apfs_unix = $date->format('U');
-                            $apfs_snapshots = $apfs_unix.", ".$apfs_snapshots;
-                        }
-                    }
-                    $this->apfs_snapshots = $apfs_snapshots;
-                }
-
-                // Fill in older legacy values
-                if (array_key_exists("legacy_output", $plist) && $plist["legacy_output"] == "Mac OS X 10.12+ not supported with legacy Time Machine log output") {
-                    // Null the duration because we can't get that on 10.12+ *sad panda*
-                    $this->duration = null;
-                    if ($plist["Destinations"][0]["RESULT"] != "0"){
-                        // Record failure time using same format as legacy
-                        $this->last_failure = date("Y-m-d H:i:s");
-                        // Record the result for processing by the UI view
-                        $this->last_failure_msg = $plist["Destinations"][0]["RESULT"];
-                    }
-                }
+            } else {
+                $this->last_failure = null;
+                $this->last_failure_msg = null;
+                $this->duration = null;
             }
         }
         
-        // Only store if there is data
-        if ($this->last_success or $this->last_failure) {
-            $this->save();
-        }
+        // Save the data, bees?
+        $this->save();
     }
 }

--- a/views/timemachine_listing.php
+++ b/views/timemachine_listing.php
@@ -1,12 +1,5 @@
 <?php $this->view('partials/head'); ?>
 
-<?php
-//Initialize models needed for the table
-new Machine_model;
-new Reportdata_model;
-new Timemachine_model;
-?>
-
 <div class="container">
 
   <div class="row">
@@ -59,7 +52,7 @@ new Timemachine_model;
 
         $('.table th').map(function(){
 
-            columnDefs.push({name: $(this).data('colname'), targets: col});
+            columnDefs.push({name: $(this).data('colname'), targets: col, render: $.fn.dataTable.render.text()});
 
             if($(this).data('sort')){
               mySort.push([col, $(this).data('sort')])
@@ -77,7 +70,7 @@ new Timemachine_model;
                 url: appUrl + '/datatables/data',
                 type: "POST",
                 data: function(d){
-                    d.mrColNotEmpty = "timemachine.id"
+                    d.mrColNotEmpty = "last_success"
                 }
             },
             dom: mr.dt.buttonDom,

--- a/views/timemachine_tab.php
+++ b/views/timemachine_tab.php
@@ -1,112 +1,130 @@
-<div id="timemachine-tab"></div>
-<h2 data-i18n="timemachine.timemachine"></h2>
+<div id="timemachine-tab">
+    <h2 data-i18n="timemachine.timemachine"></h2>
+</div>
+
+<div id="timemachine-msg" data-i18n="listing.loading" class="col-lg-12 text-center"></div>
 
 <script>
 $(document).on('appReady', function(){
 	$.getJSON(appUrl + '/module/timemachine/get_tab_data/' + serialNumber, function(data){
-		var skipThese = ['id','serial_number','destinations','localized_disk_image_volume_name','alias_volume_name'];
-		$.each(data, function(i,d){
 
-			// Generate rows from data
-			var rows = ''
-			for (var prop in d){
-				// Skip skipThese
-				if(skipThese.indexOf(prop) == -1){
-                    if (d[prop] == '' || d[prop] == null){
-					   // Do nothing for empty values to blank them
-                    } else if(prop.indexOf('bytes') > -1){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+fileSize(d[prop], 2)+'</td></tr>';
+        // Check if we have data
+        if( data[0]['alias_volume_name'] == null){
+            $('#timemachine-msg').text(i18n.t('no_data'));
+            $('#timemachine-header').removeClass('hide');
 
-                    } else if(prop == "duration"){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td><span title="'+d[prop]+' '+i18n.t('power.seconds')+'">'+moment.duration(+d[prop], "seconds").humanize()+'</span></td></tr>';
+        } else {
 
-                    } else if(prop == "last_success" || prop == "last_failure"){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td><span title="' + moment(d[prop]).format('llll') + '">'+moment(d[prop] + 'Z').fromNow()+'</span></td></tr>';
+            // Hide
+            $('#timemachine-msg').text('');
+            $('#timemachine-view').removeClass('hide');
 
-                    } else if(prop == "earliest_snapshot_date" || prop == "latest_snapshot_date"){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td><span title="' + moment(d[prop]).fromNow() + '">'+moment(d[prop] + 'Z').format('llll')+'</span></td></tr>';
+            var skipThese = ['id','serial_number','destinations','localized_disk_image_volume_name','alias_volume_name'];
+            $.each(data, function(i,d){
 
-                    } else if(prop == "consistency_scan_date" || prop == "date_of_latest_warning" || prop == "last_configuration_trace_date"){
-					   var date = new Date(d[prop] * 1000);
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td><span title="'+moment(date).fromNow()+'">'+moment(date).format('llll')+'</span></td></tr>';
+                // Generate rows from data
+                var rows = ''
+                for (var prop in d){
+                    // Skip skipThese
+                    if(skipThese.indexOf(prop) == -1){
+                        if (d[prop] == '' || d[prop] == null){
+                           // Do nothing for empty values to blank them
+                        } else if(prop.indexOf('bytes') > -1){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+fileSize(d[prop], 2)+'</td></tr>';
 
-                    } else if(prop == 'result'){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('timemachine.'+d[prop])+'</td></tr>';
-                        
-                    } else if(prop == 'last_failure_msg' && ! d[prop].startsWith("Backup failed with error ", 0)){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('timemachine.'+d[prop])+'</td></tr>';
+                        } else if(prop == "duration"){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td><span title="'+d[prop]+' '+i18n.t('power.seconds')+'">'+moment.duration(+d[prop], "seconds").humanize()+'</span></td></tr>';
 
-                    } else if(d[prop] == 'NotEncrypted'){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('unencrypted')+'</td></tr>';
-                    } else if(d[prop] == 'Encrypted'){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('encrypted')+'</td></tr>';
+                        } else if(prop == "last_success" || prop == "last_failure"){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td><span title="' + moment(d[prop]).format('llll') + '">'+moment(d[prop] + 'Z').fromNow()+'</span></td></tr>';
 
-                    } else if(prop == 'always_show_deleted_backups_warning' && d[prop] == 1){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
-                    } else if(prop == 'always_show_deleted_backups_warning' && d[prop] == 0){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
-                    }
+                        } else if(prop == "earliest_snapshot_date" || prop == "latest_snapshot_date"){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td><span title="' + moment(d[prop]).fromNow() + '">'+moment(d[prop] + 'Z').format('llll')+'</span></td></tr>';
 
-                    else if(prop == 'auto_backup' && d[prop] == 1){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
-                    } else if(prop == 'auto_backup' && d[prop] == 0){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
-                    }
+                        } else if(prop == "consistency_scan_date" || prop == "date_of_latest_warning" || prop == "last_configuration_trace_date"){
+                           var date = new Date(d[prop] * 1000);
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td><span title="'+moment(date).fromNow()+'">'+moment(date).format('llll')+'</span></td></tr>';
 
-                    else if(prop == 'mobile_backups' && d[prop] == 1){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
-                    } else if(prop == 'mobile_backups' && d[prop] == 0){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
-                    }
+                        } else if(prop == 'result'){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('timemachine.'+d[prop])+'</td></tr>';
 
-                    else if(prop == 'skip_system_files' && d[prop] == 1){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
-                    } else if(prop == 'skip_system_files' && d[prop] == 0){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
-                    }
+                        } else if(prop == 'last_failure_msg' && ! d[prop].startsWith("Backup failed with error ", 0)){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('timemachine.'+d[prop])+'</td></tr>';
 
-                    else if(prop == 'is_network_destination' && d[prop] == 1){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
-                    } else if(prop == 'is_network_destination' && d[prop] == 0){
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
+                        } else if(d[prop] == 'NotEncrypted'){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('unencrypted')+'</td></tr>';
+                        } else if(d[prop] == 'Encrypted'){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('encrypted')+'</td></tr>';
 
-                    } else if(prop == "snapshot_dates"){
-					   var snapdates = d[prop].split(", ");
-					   var outsnaps = "";
-					   snapdates.forEach(function(snapdate) {
-                           var date = new Date(snapdate * 1000);
-                           outsnaps = outsnaps + '<span title="'+moment(date).fromNow()+'">'+moment(date).format('llll')+'</span><br>'
-					   });
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+outsnaps+'</td></tr>';
+                        } else if(prop == 'always_show_deleted_backups_warning' && d[prop] == 1){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
+                        } else if(prop == 'always_show_deleted_backups_warning' && d[prop] == 0){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
+                        }
 
-                     } else if(prop == "apfs_snapshots"){
-					   var apfsdates = d[prop].split(", ");
-					   var outsnaps = "";
-					   apfsdates.forEach(function(snapdate) {
-                           if (snapdate != "") {
+                        else if(prop == 'auto_backup' && d[prop] == 1){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
+                        } else if(prop == 'auto_backup' && d[prop] == 0){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
+                        }
+
+                        else if(prop == 'mobile_backups' && d[prop] == 1){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
+                        } else if(prop == 'mobile_backups' && d[prop] == 0){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
+                        }
+
+                        else if(prop == 'skip_system_files' && d[prop] == 1){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
+                        } else if(prop == 'skip_system_files' && d[prop] == 0){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
+                        }
+
+                        else if(prop == 'is_network_destination' && d[prop] == 1){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('yes')+'</td></tr>';
+                        } else if(prop == 'is_network_destination' && d[prop] == 0){
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+i18n.t('no')+'</td></tr>';
+
+                        } else if(prop == "snapshot_dates"){
+                           var snapdates = d[prop].split(", ");
+                           var outsnaps = "";
+                           snapdates.forEach(function(snapdate) {
                                var date = new Date(snapdate * 1000);
                                outsnaps = outsnaps + '<span title="'+moment(date).fromNow()+'">'+moment(date).format('llll')+'</span><br>'
-                           }
-					   });
-					   rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+outsnaps+'</td></tr>';
-                        
-                    } else {
-                        rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+d[prop]+'</td></tr>';
-					}
-				}
-			}
-			$('#timemachine-tab')
-				.append($('<h4>')
-					.append($('<i>')
-						.addClass('fa fa-clock-o'))
-					.append(' '+d.alias_volume_name))
-				.append($('<div>')
-					.addClass('table-responsive')
-					.append($('<table>')
-						.addClass('table table-striped table-condensed')
-						.append($('<tbody>')
-							.append(rows))))
-		})
+                           });
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+outsnaps+'</td></tr>';
+
+                         } else if(prop == "apfs_snapshots"){
+                           var apfsdates = d[prop].split(", ");
+                           var outsnaps = "";
+                           apfsdates.forEach(function(snapdate) {
+                               if (snapdate != "") {
+                                   var date = new Date(snapdate * 1000);
+                                   outsnaps = outsnaps + '<span title="'+moment(date).fromNow()+'">'+moment(date).format('llll')+'</span><br>'
+                               }
+                           });
+                           rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+outsnaps+'</td></tr>';
+
+                        } else {
+                            rows = rows + '<tr><th>'+i18n.t('timemachine.'+prop)+'</th><td>'+d[prop]+'</td></tr>';
+                        }
+                    }
+                }
+
+                // Fill in table
+                $('#timemachine-tab')
+                    .append($('<h4>')
+                        .append($('<i>')
+                            .addClass('fa fa-clock-o'))
+                        .append(' '+d.alias_volume_name))
+                    .append($('<div>')
+                        .addClass('table-responsive')
+                        .append($('<table>')
+                            .addClass('table table-striped table-condensed')
+                            .append($('<tbody>')
+                                .append(rows))))
+            })
+        }
 	});
 });
 </script>


### PR DESCRIPTION
Machines previously had lots of empty data being saved. PR resolves this by nulling data for machines that do not have Time Machine enabled. Changed client tab and listing to better reflect empty/null data